### PR TITLE
モード切替をしたときに最後尾の文字が消えるバグ

### DIFF
--- a/static/js/preview.js
+++ b/static/js/preview.js
@@ -155,7 +155,6 @@ function addChangeHandle(e){
     }else{
       newId = addSubTask(getParentTaskId(id), '');
     }
-    console.log(newId);
     $(`#${newId} .task-name`).focus();
   }else if(e.ctrlKey && e.keyCode == 39){  // →
     let newId = addSubTask(id, '');
@@ -222,7 +221,7 @@ function addSubTask(id, content){
           placeholder: 'Task name',
           value: subTask.name,
           on: {
-            keydown: function(e){
+            keyup: function(e){
               addChangeHandle(e);
             }
           }
@@ -323,7 +322,7 @@ function constructionCardChildrenTask(children){
           placeholder: 'Task name',
           value: c.name,
           on: {
-            keydown: function(e){
+            keyup: function(e){
               addChangeHandle(e);
             }
           }
@@ -368,7 +367,7 @@ function constructionCardFromTask(task){
             placeholder: 'Task name',
             value: task.name,
             on: {
-              keydown: function(e){
+              keyup: function(e){
                 addChangeHandle(e);
               }
             }


### PR DESCRIPTION
# 問題
- タスク名を入力したあとにモードを切り替えると入力していた箇所の最後の文字が消えてしまう

# 原因
- keydownイベントで見ていたので入力された文字がカウントされていなかった

# 解決
- keyupイベントで監視する